### PR TITLE
Remove burn addresses

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -9,10 +9,8 @@ use bitcoin::network::serialize::serialize;
 use bitcoin::network::serialize::SimpleDecoder;
 use bitcoin::network::serialize::SimpleEncoder;
 use bitcoin::Transaction;
-use bitcoin::util::address::Address;
 use bitcoin::util::hash::Sha256dHash;
 use std::collections::HashMap;
-use std::str::FromStr;
 use super::bitcoin::network::constants::Network;
 use super::bitcoin::OutPoint;
 use super::traits::Verify;
@@ -23,7 +21,6 @@ pub struct Contract {
     pub title: String,
     pub issuance_utxo: OutPoint,
     pub initial_owner_utxo: OutPoint,
-    pub burn_address: Address,
     pub network: Network,
     pub total_supply: u32,
 }
@@ -78,7 +75,7 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for Contract {
         self.title.consensus_encode(s)?;
         self.issuance_utxo.consensus_encode(s)?;
         self.initial_owner_utxo.consensus_encode(s)?;
-        self.burn_address.to_string().consensus_encode(s)?;
+
         self.network.consensus_encode(s)?;
         self.total_supply.consensus_encode(s)
     }
@@ -89,13 +86,11 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for Contract {
         let title: String = ConsensusDecodable::consensus_decode(d)?;
         let issuance_utxo: OutPoint = ConsensusDecodable::consensus_decode(d)?;
         let initial_owner_utxo: OutPoint = ConsensusDecodable::consensus_decode(d)?;
-        let burn_address_str: String = ConsensusDecodable::consensus_decode(d)?;
 
         Ok(Contract {
             title,
             issuance_utxo,
             initial_owner_utxo,
-            burn_address: Address::from_str(burn_address_str.as_str()).unwrap(),
             network: ConsensusDecodable::consensus_decode(d)?,
             total_supply: ConsensusDecodable::consensus_decode(d)?,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@ pub mod contract;
 pub mod proof;
 pub mod traits;
 pub mod utils;
+pub mod output_entry;

--- a/src/output_entry.rs
+++ b/src/output_entry.rs
@@ -1,0 +1,41 @@
+use bitcoin::network::encodable::ConsensusDecodable;
+use bitcoin::network::encodable::ConsensusEncodable;
+use bitcoin::network::serialize;
+use bitcoin::network::serialize::SimpleDecoder;
+use bitcoin::network::serialize::SimpleEncoder;
+use bitcoin::util::hash::Sha256dHash;
+
+#[derive(Clone, Debug)]
+pub struct OutputEntry(Sha256dHash, u32, Option<u32>); // asset_id, amount -> vout
+
+impl OutputEntry {
+    pub fn new(asset_id: Sha256dHash, amount: u32, vout: Option<u32>) -> OutputEntry {
+        OutputEntry(asset_id, amount, vout)
+    }
+
+    pub fn get_asset_id(&self) -> Sha256dHash {
+        self.0.clone()
+    }
+
+    pub fn get_amount(&self) -> u32 {
+        self.1
+    }
+
+    pub fn get_vout(&self) -> Option<u32> {
+        self.2
+    }
+}
+
+impl<S: SimpleEncoder> ConsensusEncodable<S> for OutputEntry {
+    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
+        self.0.consensus_encode(s)?;
+        self.1.consensus_encode(s)?;
+        self.2.consensus_encode(s)
+    }
+}
+
+impl<D: SimpleDecoder> ConsensusDecodable<D> for OutputEntry {
+    fn consensus_decode(d: &mut D) -> Result<OutputEntry, serialize::Error> {
+        Ok(OutputEntry::new(ConsensusDecodable::consensus_decode(d)?, ConsensusDecodable::consensus_decode(d)?, ConsensusDecodable::consensus_decode(d)?))
+    }
+}

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -10,33 +10,13 @@ use bitcoin::network::serialize::SimpleEncoder;
 use bitcoin::Transaction;
 use bitcoin::util::hash::Sha256dHash;
 use contract::Contract;
+use output_entry::OutputEntry;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::hash::Hasher;
 use super::bitcoin::OutPoint;
 use super::traits::Verify;
 use traits::NeededTx;
-
-#[derive(Clone, Debug)]
-pub struct OutputEntry(Sha256dHash, u32, u32); // asset_id, amount -> vout
-
-impl OutputEntry {
-    pub fn new(asset_id: Sha256dHash, amount: u32, vout: u32) -> OutputEntry {
-        OutputEntry(asset_id, amount, vout)
-    }
-
-    pub fn get_asset_id(&self) -> Sha256dHash {
-        self.0.clone()
-    }
-
-    pub fn get_amount(&self) -> u32 {
-        self.1
-    }
-
-    pub fn get_vout(&self) -> u32 {
-        self.2
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct Proof {
@@ -79,28 +59,13 @@ impl Proof {
             let input_for_us = committing_tx_this.input[i].previous_output.vout;
 
             for entry in &test_proof.output {
-                if entry.2 == input_for_us {
+                if entry.get_vout().is_some() && entry.get_vout().unwrap() == input_for_us {
                     ans.push(entry.clone());
                 }
             }
         }
 
         ans
-    }
-
-    pub fn get_contract_for(&self, asset_id: Sha256dHash) -> Option<Contract> {
-        if self.is_root_proof() && self.contract.as_ref().unwrap().get_asset_id() == asset_id {
-            return Some(self.contract.as_ref().unwrap().as_ref().clone());
-        } else {
-            for input in &self.input {
-                let result = input.get_contract_for(asset_id);
-                if result.is_some() {
-                    return result;
-                }
-            }
-        }
-
-        None
     }
 }
 
@@ -169,8 +134,6 @@ impl Verify for Proof {
         let mut in_amounts = HashMap::new();
 
         if self.is_root_proof() {
-            // Burn addresses are only checked in normal proofs, not root proofs
-
             if self.input.len() > 0 {
                 println!("the root proof should not have any input proofs");
                 return false;
@@ -183,26 +146,12 @@ impl Verify for Proof {
             for input_proof in &self.input {
                 let mut entries_for_us = self.get_entries_for_us(input_proof, &needed_txs);
                 in_entries.append(&mut entries_for_us);
-
-                // -------------------------------------------------------
-                // Make sure we are not spending burned assets
-
-                let tx_spent = needed_txs.get(&NeededTx::WhichSpendsOutPoint(input_proof.bind_to[0])).unwrap();
-                for entry in &entries_for_us {
-                    let index: usize = entry.get_vout() as usize;
-                    let script_pubkey = &tx_spent.output[index].script_pubkey;
-
-                    if script_pubkey == &self.get_contract_for(entry.get_asset_id()).unwrap().burn_address.script_pubkey() {
-                        println!("Trying to spend burned coins!");
-                        return false;
-                    }
-                }
             }
 
             // Aggregate the amounts
             for entry in in_entries {
-                let aggregator = in_amounts.entry(entry.0).or_insert(0);
-                *aggregator += entry.1;
+                let aggregator = in_amounts.entry(entry.get_asset_id()).or_insert(0);
+                *aggregator += entry.get_amount();
             }
         }
 
@@ -212,8 +161,8 @@ impl Verify for Proof {
         let mut out_amounts = HashMap::new();
 
         for output_entry in &self.output {
-            let aggregator = out_amounts.entry(output_entry.0).or_insert(0);
-            *aggregator += output_entry.1;
+            let aggregator = out_amounts.entry(output_entry.get_asset_id()).or_insert(0);
+            *aggregator += output_entry.get_amount();
         }
 
         if in_amounts != out_amounts {
@@ -246,20 +195,6 @@ impl Hash for Proof {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let consensus_hash = self.bitcoin_hash();
         consensus_hash.hash(state);
-    }
-}
-
-impl<S: SimpleEncoder> ConsensusEncodable<S> for OutputEntry {
-    fn consensus_encode(&self, s: &mut S) -> Result<(), serialize::Error> {
-        self.0.consensus_encode(s)?;
-        self.1.consensus_encode(s)?;
-        self.2.consensus_encode(s)
-    }
-}
-
-impl<D: SimpleDecoder> ConsensusDecodable<D> for OutputEntry {
-    fn consensus_decode(d: &mut D) -> Result<OutputEntry, serialize::Error> {
-        Ok(OutputEntry::new(ConsensusDecodable::consensus_decode(d)?, ConsensusDecodable::consensus_decode(d)?, ConsensusDecodable::consensus_decode(d)?))
     }
 }
 


### PR DESCRIPTION
Tokens are burned by setting the `vout` of an `OutputEntry` to `None` instead of `Some(u32)`.

`OutputEntry` itself has been moved out of proof.rs into a dedicated file.