### PR TITLE
Replace OP_RETURNs with pay-to-contract commitments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Alekos Filini <alekos.filini@gmail.com>"]
 
 [dependencies]
 bitcoin = "~0.14.2"
+secp256k1 = "~0.11.2"

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,5 +1,5 @@
 use bitcoin::BitcoinHash;
-use bitcoin::blockdata::opcodes::*;
+use bitcoin::blockdata::opcodes;
 use bitcoin::blockdata::script::Builder;
 use bitcoin::blockdata::script::Script;
 use bitcoin::network::encodable::ConsensusDecodable;
@@ -10,13 +10,19 @@ use bitcoin::network::serialize::SimpleDecoder;
 use bitcoin::network::serialize::SimpleEncoder;
 use bitcoin::Transaction;
 use bitcoin::util::address::Address;
+use bitcoin::util::hash::Hash160;
 use bitcoin::util::hash::Sha256dHash;
+use pay_to_contract::ECTweakFactor;
+use secp256k1::Error;
+use secp256k1::PublicKey;
+use secp256k1::Secp256k1;
 use std::collections::HashMap;
 use std::str::FromStr;
 use super::bitcoin::network::constants::Network;
 use super::bitcoin::OutPoint;
 use super::traits::Verify;
 use traits::NeededTx;
+use traits::PayToContract;
 
 #[derive(Clone, Debug)]
 pub struct Contract {
@@ -26,6 +32,7 @@ pub struct Contract {
     pub burn_address: Address,
     pub network: Network,
     pub total_supply: u32,
+    pub original_commitment_pk: Option<PublicKey>
 }
 
 impl Contract {
@@ -36,6 +43,8 @@ impl Contract {
 
 impl BitcoinHash for Contract {
     fn bitcoin_hash(&self) -> Sha256dHash { // all the fields
+        // TODO: leave out "original_commitment_pk": it's not necessary to "pre-commit" to this value,
+        // and doing so could actually make some tokens/bitcoins unspendable (if original_commitment_pk is not set)
         Sha256dHash::from_data(&serialize(self).unwrap())
     }
 }
@@ -47,15 +56,9 @@ impl Verify for Contract {
 
     fn verify(&self, needed_txs: &HashMap<&NeededTx, Transaction>) -> bool {
         let committing_tx = needed_txs.get(&NeededTx::WhichSpendsOutPoint(self.issuance_utxo)).unwrap();
-        let expected = self.get_expected_script();
 
-        // Check the outputs
-        let mut found_output = false;
-        for i in 0..committing_tx.output.len() {
-            found_output = found_output || committing_tx.output[i].script_pubkey == expected;
-        }
-
-        if !found_output {
+        // TODO: signal the commitment output somehow
+        if committing_tx.output[0].script_pubkey != self.get_expected_script() {
             println!("invalid commitment");
             return false;
         }
@@ -64,12 +67,38 @@ impl Verify for Contract {
     }
 
     fn get_expected_script(&self) -> Script {
-        let burn_script_builder = Builder::new();
+        let mut contract_pubkey = self.original_commitment_pk.unwrap().clone();
 
-        let burn_script_builder = burn_script_builder.push_opcode(All::OP_RETURN);
-        let burn_script_builder = burn_script_builder.push_slice(self.bitcoin_hash().as_bytes());
+        let s = Secp256k1::new();
+        self.get_self_tweak_factor().unwrap().add_to_pk(&s, &mut contract_pubkey).unwrap();
 
-        burn_script_builder.into_script()
+        Builder::new()
+            .push_opcode(opcodes::All::OP_DUP)
+            .push_opcode(opcodes::All::OP_HASH160)
+            .push_slice(&(Hash160::from_data(&contract_pubkey.serialize()[..])[..]))
+            .push_opcode(opcodes::All::OP_EQUALVERIFY)
+            .push_opcode(opcodes::All::OP_CHECKSIG)
+            .into_script()
+    }
+}
+
+impl PayToContract for Contract {
+    fn set_commitment_pk(&mut self, pk: &PublicKey) -> (PublicKey, ECTweakFactor) {
+        self.original_commitment_pk = Some(pk.clone()); // set the original pk
+
+        let s = Secp256k1::new();
+
+        let mut new_pk = pk.clone();
+        let tweak_factor = self.get_self_tweak_factor().unwrap();
+        tweak_factor.add_to_pk(&s, &mut new_pk).unwrap();
+
+        (new_pk, tweak_factor)
+    }
+
+    fn get_self_tweak_factor(&self) -> Result<ECTweakFactor, Error> {
+        let s = Secp256k1::new();
+
+        ECTweakFactor::from_pk_data(&s, &self.original_commitment_pk.unwrap(), &self.bitcoin_hash())
     }
 }
 
@@ -80,7 +109,18 @@ impl<S: SimpleEncoder> ConsensusEncodable<S> for Contract {
         self.initial_owner_utxo.consensus_encode(s)?;
         self.burn_address.to_string().consensus_encode(s)?;
         self.network.consensus_encode(s)?;
-        self.total_supply.consensus_encode(s)
+        self.total_supply.consensus_encode(s)?;
+
+        let original_commitment_pk_ser: Vec<u8> = match self.original_commitment_pk {
+            Some(pk) => {
+                let mut vec = Vec::with_capacity(33);
+                vec.extend_from_slice(&pk.serialize());
+
+                vec
+            },
+            None => Vec::new()
+        };
+        original_commitment_pk_ser.consensus_encode(s)
     }
 }
 
@@ -91,13 +131,22 @@ impl<D: SimpleDecoder> ConsensusDecodable<D> for Contract {
         let initial_owner_utxo: OutPoint = ConsensusDecodable::consensus_decode(d)?;
         let burn_address_str: String = ConsensusDecodable::consensus_decode(d)?;
 
-        Ok(Contract {
+        let mut c = Contract {
             title,
             issuance_utxo,
             initial_owner_utxo,
             burn_address: Address::from_str(burn_address_str.as_str()).unwrap(),
             network: ConsensusDecodable::consensus_decode(d)?,
             total_supply: ConsensusDecodable::consensus_decode(d)?,
-        })
+            original_commitment_pk: None
+        };
+
+        let original_commitment_pk_ser: Vec<u8> = ConsensusDecodable::consensus_decode(d)?;
+        if original_commitment_pk_ser.len() > 0 {
+            let s = Secp256k1::new();
+            c.set_commitment_pk(&PublicKey::from_slice(&s, &original_commitment_pk_ser.as_slice()).unwrap());
+        }
+
+        Ok(c)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate bitcoin;
+extern crate core;
+extern crate secp256k1;
 
 #[cfg(test)]
 mod tests;
@@ -7,3 +9,4 @@ pub mod contract;
 pub mod proof;
 pub mod traits;
 pub mod utils;
+pub mod pay_to_contract;

--- a/src/pay_to_contract.rs
+++ b/src/pay_to_contract.rs
@@ -1,0 +1,37 @@
+use bitcoin::util::hash::Sha256dHash;
+use secp256k1::Error;
+use secp256k1::PublicKey;
+use secp256k1::Secp256k1;
+use secp256k1::SecretKey;
+use secp256k1::Verification;
+use std::fmt;
+
+// Create a wrapper around secp256k1's data type, to improve readability
+pub struct ECTweakFactor(SecretKey);
+
+impl ECTweakFactor {
+    pub fn from_pk_data<C>(secp: &Secp256k1<C>, pk: &PublicKey, data: &Sha256dHash) -> Result<ECTweakFactor, Error> {
+        let mut tmp = [0; 65];
+
+        tmp[..33].copy_from_slice(&pk.serialize());
+        tmp[33..].copy_from_slice(data.as_bytes());
+
+        let tweak_factor = SecretKey::from_slice(&secp, Sha256dHash::from_data(&tmp).as_bytes())?;
+
+        Ok(ECTweakFactor(tweak_factor))
+    }
+
+    pub fn as_inner(&self) -> &SecretKey {
+        &self.0
+    }
+
+    pub fn add_to_pk<C: Verification>(&self, secp: &Secp256k1<C>, pk: &mut PublicKey) -> Result<(), Error> {
+        pk.add_exp_assign(&secp, &self.as_inner())
+    }
+}
+
+impl fmt::Display for ECTweakFactor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,6 +2,9 @@ use bitcoin::blockdata::script::Script;
 use bitcoin::OutPoint;
 use bitcoin::Transaction;
 use bitcoin::util::hash::Sha256dHash;
+use pay_to_contract::ECTweakFactor;
+use secp256k1::Error;
+use secp256k1::PublicKey;
 use std::collections::HashMap;
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
@@ -14,4 +17,9 @@ pub trait Verify {
     fn get_needed_txs(&self) -> Vec<NeededTx>;
     fn verify(&self, needed_txs: &HashMap<&NeededTx, Transaction>) -> bool;
     fn get_expected_script(&self) -> Script;
+}
+
+pub trait PayToContract {
+    fn set_commitment_pk(&mut self, pk: &PublicKey) -> (PublicKey, ECTweakFactor);
+    fn get_self_tweak_factor(&self) -> Result<ECTweakFactor, Error>;
 }


### PR DESCRIPTION
Still a WIP, but most of the primitives are there. This requires some changes in kaleidoscope too.