### PR TITLE
Changing total_amount contract field from u32 to u64

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -22,7 +22,7 @@ pub struct Contract {
     pub issuance_utxo: OutPoint,
     pub initial_owner_utxo: OutPoint,
     pub network: Network,
-    pub total_supply: u32,
+    pub total_supply: u64,
 }
 
 impl Contract {

--- a/src/output_entry.rs
+++ b/src/output_entry.rs
@@ -6,10 +6,10 @@ use bitcoin::network::serialize::SimpleEncoder;
 use bitcoin::util::hash::Sha256dHash;
 
 #[derive(Clone, Debug)]
-pub struct OutputEntry(Sha256dHash, u32, Option<u32>); // asset_id, amount -> vout
+pub struct OutputEntry(Sha256dHash, u64, Option<u32>); // asset_id, amount -> vout
 
 impl OutputEntry {
-    pub fn new(asset_id: Sha256dHash, amount: u32, vout: Option<u32>) -> OutputEntry {
+    pub fn new(asset_id: Sha256dHash, amount: u64, vout: Option<u32>) -> OutputEntry {
         OutputEntry(asset_id, amount, vout)
     }
 
@@ -17,7 +17,7 @@ impl OutputEntry {
         self.0.clone()
     }
 
-    pub fn get_amount(&self) -> u32 {
+    pub fn get_amount(&self) -> u64 {
         self.1
     }
 


### PR DESCRIPTION
to overcome the limitation of ~4 billion asset units and make it compatible with Bitcoin satoshi dimension – as was suggested by Stefano Pellegrini @St333p